### PR TITLE
feat: fix nest schema ref parse fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw?
+yarn.lock

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,7 @@
 import Vue from "vue";
 import Vuex from "vuex";
 import JSRP from "json-schema-ref-parser";
+import { dereference } from "./utils/nest_ref_parser"
 
 Vue.use(Vuex);
 
@@ -141,9 +142,11 @@ export default new Vuex.Store({
         state.apis[payload.apiId].openrpc.document.modified.schema =
           payload.json;
       }
+
       // JSON deep copy fuckery to prevent deref referencing payload.json (we don't want the deref going back to schema)
-      JSRP.dereference(
-        JSON.parse(JSON.stringify(payload.json)),
+      var copyPayload = JSON.parse(JSON.stringify(payload.json))
+
+      dereference(copyPayload,
         (err, deref) => {
           if (err) {
             state.errors.push(err);
@@ -167,9 +170,12 @@ export default new Vuex.Store({
     setOpenRpcModified(state, payload) {
       state.apis[payload.apiId].openrpc.document.modified.schema = payload.json;
       state.apis[payload.apiId].openrpc.error = false; // reset error
+
       // JSON deep copy fuckery to prevent deref referencing payload.json (we don't want the deref going back to schema)
-      JSRP.dereference(
-        JSON.parse(JSON.stringify(payload.json)),
+      var copyPayload = JSON.parse(JSON.stringify(payload.json))
+
+      dereference(
+        copyPayload,
         (err, deref) => {
           if (err) {
             state.errors.push(err);

--- a/src/utils/nest_ref_parser.js
+++ b/src/utils/nest_ref_parser.js
@@ -1,0 +1,25 @@
+
+import JSRP from "json-schema-ref-parser";
+
+export function dereference(json_obj, callback) {
+    let parser = new JSRP();
+
+    inne_parse(parser, json_obj).then(function(){
+        callback && callback(null, json_obj)
+    }).catch(function(e){
+        callback && callback(e)
+    })
+}
+
+async function inne_parse(parser, json_obj) {
+    for (const [key, value] of Object.entries(json_obj)) {    
+        if (key == "schema") {
+            var schema = await parser.dereference(value)
+            json_obj[key] = schema
+        } else {
+            if (Object.prototype.toString.call(value) === '[Object Object]') {
+                await inne_parse(parser, value)
+            }
+        }
+    }
+}

--- a/src/utils/nest_ref_parser.js
+++ b/src/utils/nest_ref_parser.js
@@ -14,7 +14,7 @@ export function dereference(json_obj, callback) {
 async function inne_parse(parser, json_obj) {
     for (const [key, value] of Object.entries(json_obj)) {    
         if (key == "schema") {
-            var schema = await parser.dereference(value)
+            let schema = await parser.dereference(value)
             json_obj[key] = schema
         } else {
             if (Object.prototype.toString.call(value) === '[Object Object]') {


### PR DESCRIPTION
原因：json-schema-ref-parser 库不支持内嵌schema的解析

修复后结果：
![image](https://user-images.githubusercontent.com/1449069/163293907-7da396a9-7ade-4351-aca3-ed820228eccc.png)
![image](https://user-images.githubusercontent.com/1449069/163293970-2d08b469-0e05-4e69-88c6-1d2f9e289890.png)
